### PR TITLE
feat: add /ping endpoint - closes #9

### DIFF
--- a/api/src/index.js
+++ b/api/src/index.js
@@ -106,3 +106,12 @@ if (process.env.NODE_ENV !== 'test') {
 }
 
 module.exports = { app, server };
+
+// Ping endpoint - Issue #9
+app.get('/ping', (req, res) => {
+  res.json({
+    message: 'pong',
+    timestamp: new Date().toISOString(),
+    version: process.env.APP_VERSION || '0.0.0'
+  });
+});

--- a/api/tests/health.test.js
+++ b/api/tests/health.test.js
@@ -31,3 +31,12 @@ describe('Status endpoint', () => {
     expect(res.body.uptime_seconds).toBeDefined();
   });
 });
+
+describe('Ping endpoint', () => {
+  test('GET /ping returns pong', async () => {
+    const res = await request(app).get('/ping');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.message).toBe('pong');
+    expect(res.body.timestamp).toBeDefined();
+  });
+});


### PR DESCRIPTION

## 📋 Descripción
Agrega endpoint GET /ping que retorna pong 
y timestamp para verificar que el servicio está activo.

## 🔗 Ticket relacionado
Closes #9

## 🧪 Tipo de cambio
- [x] Feature nueva

## ✅ Checklist
- [x] Tests pasan localmente (`npm test`)
- [x] Lint pasa (`npm run lint`)
- [x] No hay secretos en el código
- [x] Docker build exitoso
- [x] Documentación actualizada si aplica

## 📸 Evidencia
- 4 tests pasando: /health, /version, /status, /ping
- Endpoint retorna pong y timestamp